### PR TITLE
Discord: always post daily 9 PM sweep summary (incl. quiet days + err…

### DIFF
--- a/applications_monitor_backend/index.js
+++ b/applications_monitor_backend/index.js
@@ -8400,11 +8400,14 @@ async function runClientMilestoneCron({ trigger = 'cron', verbose = false } = {}
   const tookMs = Date.now() - startedAt;
   console.log(`[Client Milestones] sweep done in ${tookMs}ms processed=${summary.processed} sent=${summary.sent} failed=${summary.failed} skipped=${summary.skipped} errors=${summary.errors}`);
 
-  // Post a beautified Discord summary (skips silent no-op runs internally).
+  // Post a beautified Discord summary. The daily 9 PM runs (cron / external-cron)
+  // ALWAYS post — a heartbeat even on quiet days ("no milestone emails due") and
+  // on errors. Other triggers (boot redeploy, admin) stay quiet on no-op runs.
   // Never let a notification failure affect the sweep result.
   try {
     const sender = await getActiveGmailSender();
-    await notifyMilestoneSweep({ ...summary, tookMs }, { trigger, senderEmail: sender?.email });
+    const isDaily = trigger === 'cron' || trigger === 'external-cron';
+    await notifyMilestoneSweep({ ...summary, tookMs }, { trigger, senderEmail: sender?.email, always: isDaily });
   } catch (e) {
     console.error('[Client Milestones] discord summary failed:', e?.message || e);
   }

--- a/applications_monitor_backend/utils/discordMilestoneNotify.js
+++ b/applications_monitor_backend/utils/discordMilestoneNotify.js
@@ -106,13 +106,15 @@ export async function notifyGmailAuthError({ error, senderEmail, recipient, cate
  * @param {Object} summary - { processed, sent, failed, skipped, errors, tookMs, details[] }
  * @param {Object} [opts]  - { trigger, senderEmail }
  */
-export async function notifyMilestoneSweep(summary = {}, { trigger = 'cron', senderEmail } = {}) {
+export async function notifyMilestoneSweep(summary = {}, { trigger = 'cron', senderEmail, always = false } = {}) {
   const details = Array.isArray(summary.details) ? summary.details : [];
   const failures = details.filter((d) => d && (d.status === 'failed' || d.status === 'error'));
   const sent = summary.sent || 0;
 
-  // Nothing happened and nothing broke → don't ping.
-  if (!sent && !failures.length) return;
+  // Nothing happened and nothing broke → only ping when `always` (the daily
+  // 9 PM run wants a heartbeat even on quiet days). Other triggers (boot,
+  // admin) stay quiet on no-op runs.
+  if (!sent && !failures.length && !always) return;
 
   const hasAuth = failures.some((f) => isGmailAuthError(f.error));
   const failCount = (summary.failed || 0) + (summary.errors || 0);
@@ -121,9 +123,12 @@ export async function notifyMilestoneSweep(summary = {}, { trigger = 'cron', sen
   if (failures.length) {
     statusLine = hasAuth ? '🔐 Auth error — emails NOT sending' : '⚠️ Completed with failures';
     color = hasAuth ? 0xef4444 : 0xf59e0b; // red / amber
-  } else {
+  } else if (sent) {
     statusLine = '✅ Completed';
     color = 0x22c55e; // green
+  } else {
+    statusLine = '🟢 No milestone emails due today';
+    color = 0x3b82f6; // blue — quiet, healthy day
   }
 
   const fields = [
@@ -146,6 +151,14 @@ export async function notifyMilestoneSweep(summary = {}, { trigger = 'cron', sen
     fields.push({
       name: `Failures (${failures.length})`,
       value: (lines.join('\n') + extra).slice(0, 1024),
+      inline: false,
+    });
+  }
+
+  if (!sent && !failures.length) {
+    fields.push({
+      name: 'Result',
+      value: `No client reached a new milestone today — checked ${summary.processed || 0} active client(s), all caught up. No emails were due.`,
       inline: false,
     });
   }


### PR DESCRIPTION
…ors)

- notifyMilestoneSweep gains an always flag. Daily triggers (cron / external-cron) always post a heartbeat — even when nothing was due ('No milestone emails due today', blue) — plus failures/auth errors as before.
- boot/admin triggers stay quiet on no-op runs.