### PR TITLE
CRM: 'AI flagged' (second-stage flags) instead of 'Removed by AI'

### DIFF
--- a/applications-monitor-frontend-main/src/components/AdminSummariesPage.jsx
+++ b/applications-monitor-frontend-main/src/components/AdminSummariesPage.jsx
@@ -336,7 +336,7 @@ export default function AdminSummariesPage() {
                         <StatTile label="Profile changed" value={totals.stale || 0} sub="needs rebuild" accent="orange" />
                         <StatTile label="Ops today" value={totals.opsToday || 0} sub={`${totals.opsTotal} lifetime`} accent="blue" />
                         <StatTile label="LinkedIn skipped" value={totals.linkedinSkippedTotal || 0} sub="ext sessions" accent="rose" />
-                        <StatTile label="Removed by AI" value={totals.removedByAITotal || 0} sub={`${totals.removedTotal || 0} removed total`} accent="rose" />
+                        <StatTile label="AI flagged" value={totals.flaggedByAITotal || 0} sub={`${totals.removedTotal || 0} removed total`} accent="amber" />
                     </div>
 
                     {/* TOP OPERATORS — who pushed how many today + lifetime */}
@@ -910,12 +910,12 @@ function ClientDetailPane({ row, onProfileChanged }) {
                         onClick={openAiRemoved}
                         className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border-2 border-rose-200 bg-rose-50 text-rose-700 font-medium hover:bg-rose-100 transition"
                     >
-                        🛡️ See AI reasons to remove
+                        🛡️ See AI flags
                     </button>
                     <div className="text-xs text-slate-500">
                         Removed <span className="font-semibold text-slate-700">{row.removed ?? 0}</span>
                         <span className="mx-1">·</span>
-                        by AI <span className="font-semibold text-rose-700">{row.removedByAI ?? 0}</span>
+                        AI flagged <span className="font-semibold text-amber-700">{row.flaggedByAI ?? 0}</span>
                     </div>
                 </div>
             </div>
@@ -1162,9 +1162,9 @@ function ClientDetailPane({ row, onProfileChanged }) {
                     >
                         <div className="px-6 py-4 border-b border-slate-200 bg-rose-50 flex items-center justify-between">
                             <div>
-                                <h3 className="text-lg font-bold text-rose-800">🛡️ AI reasons to remove</h3>
+                                <h3 className="text-lg font-bold text-rose-800">🛡️ AI second-stage flags</h3>
                                 <p className="text-xs text-slate-600 mt-0.5">
-                                    {row.email} · {aiRemoved.total} job{aiRemoved.total === 1 ? '' : 's'} removed by AI
+                                    {row.email} · {aiRemoved.total} job{aiRemoved.total === 1 ? '' : 's'} flagged by AI (kept — operator decides)
                                 </p>
                             </div>
                             <button

--- a/applications-monitor-frontend-main/src/components/ClientJobAnalysis.jsx
+++ b/applications-monitor-frontend-main/src/components/ClientJobAnalysis.jsx
@@ -804,7 +804,7 @@ export default function ClientJobAnalysis() {
                 <th className="px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-700">Offer</th>
                 <th className="px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-700">Rejected</th>
                 <th className="px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-700">Removed</th>
-                <th className="px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-rose-700" title="Of the removed jobs, how many were removed by AI (second-stage screening / exclusion).">Removed by AI</th>
+                <th className="px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-amber-700" title="Jobs the AI second-stage screening flagged for operator review (location/closed). The job is KEPT — not removed.">AI flagged</th>
                 {isAdmin && (
                   <th className="px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-700" title="Admin: trigger internal JR scraper for this client. Completion + errors post to Discord.">
                     Scrape
@@ -1050,7 +1050,7 @@ export default function ClientJobAnalysis() {
                     <td className="px-2 py-1 text-right">{r.offer}</td>
                     <td className="px-2 py-1 text-right">{r.rejected}</td>
                     <td className="px-2 py-1 text-right">{r.removed}</td>
-                  <td className="px-2 py-1 text-right font-semibold text-rose-700">{r.removedByAI || 0}</td>
+                  <td className="px-2 py-1 text-right font-semibold text-amber-700">{r.flaggedByAI || 0}</td>
                     {isAdmin && (
                       <td className="px-2 py-1">
                         <div className="flex items-center gap-1">

--- a/applications_monitor_backend/index.js
+++ b/applications_monitor_backend/index.js
@@ -3445,7 +3445,7 @@ app.post('/api/analytics/client-job-analysis', async (req, res) => {
       const pLA = await pGetAnalysisCache('__lastAppliedOperator__');
       if (pLA && pLA.fresh) cachedLastApplied = pLA.val;
     }
-    const [overall, appliedOnDate, removedOnDate, removedByAiOnDate, lastAppliedAgg, clientInfo] = await Promise.all([
+    const [overall, appliedOnDate, removedOnDate, removedByAiOnDate, lastAppliedAgg, clientInfo, flaggedAgg] = await Promise.all([
       // 1) Overall counts per client, grouped on the RAW status. No regex/$switch
       //    in the pipeline — Mongo can satisfy this from the { userID:1, currentStatus:1 }
       //    index (covered scan, no document fetch). Buckets are folded in JS below.
@@ -3511,7 +3511,14 @@ app.post('/api/analytics/client-job-analysis', async (req, res) => {
       // 5) Client info — runs in parallel with aggregations (no dependency)
       ClientModel.find({})
         .select('email name clientNumber planType planPrice status jobStatus operationsName dashboardTeamLeadName isPaused onboardingPhase addons pausedAt clientCountry')
-        .lean()
+        .lean(),
+      // 6) AI second-stage FLAGS per client (secondJudge.status:'failed') —
+      //    advisory flags the AI raised; the job is KEPT, not removed.
+      JobModel.aggregate([
+        { $match: { 'secondJudge.status': 'failed' } },
+        { $group: { _id: '$userID', count: { $sum: 1 } } },
+        { $project: { _id: 0, userID: '$_id', count: 1 } }
+      ])
     ]);
 
     // Cache last-applied operator separately with longer TTL (5 min)
@@ -3523,6 +3530,7 @@ app.post('/api/analytics/client-job-analysis', async (req, res) => {
     const appliedMap = new Map(appliedOnDate.map(r => [r.userID, r.count]));
     const removedMap = new Map(removedOnDate.map(r => [r.userID, r.count]));
     const removedByAiMap = new Map(removedByAiOnDate.map(r => [r.userID, r.count]));
+    const flaggedMap = new Map((flaggedAgg || []).map(r => [r.userID, r.count]));
     // Fold raw {userID,status} groups into per-user bucket counts (JS, cheap).
     const overallMap = new Map();
     for (const g of overall) {
@@ -3632,6 +3640,7 @@ app.post('/api/analytics/client-job-analysis', async (req, res) => {
         rejected: counts.rejected || 0,
         removed: removedCount,
         removedByAI: removedByAICount,
+        flaggedByAI: flaggedMap.get(email) || 0,
         appliedOnDate: appliedMap.get(email) || 0
       };
     });


### PR DESCRIPTION
Second judge now flags (keeps) rather than removes, so the CRM column, overview tile, per-client line, and the modal now reflect secondJudge.status='failed' flagged jobs. Modal relabeled 'See AI flags'.