### PR TITLE
fix: add stripe dependency and root package.json for Render deploy

### DIFF
--- a/applications_monitor_backend/package.json
+++ b/applications_monitor_backend/package.json
@@ -38,6 +38,7 @@
     "multer": "^1.4.5-lts.1",
     "node-cron": "^4.2.1",
     "nodemailer": "^8.0.11",
+    "stripe": "^17.7.0",
     "twilio": "^5.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "clients-tracking-root",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "cd applications_monitor_backend && npm install",
+    "start": "cd applications_monitor_backend && npm start"
+  }
+}


### PR DESCRIPTION
## Summary
- `stripe` was imported in `applications_monitor_backend/index.js` but missing from its `package.json`, causing `ERR_MODULE_NOT_FOUND` on every Render deploy startup
- Added a root-level `package.json` with `postinstall` and `start` scripts so Render's default build (`npm install`) and start (`npm start`) commands work correctly from the repo root

## Test plan
- [ ] Deploy to Render — server should start without `ERR_MODULE_NOT_FOUND`
- [ ] Verify Stripe-related endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)