### PR TITLE
Add British Pound (GBP/£) currency support

### DIFF
--- a/applications-monitor-frontend-main/src/components/ClientDashboard.jsx
+++ b/applications-monitor-frontend-main/src/components/ClientDashboard.jsx
@@ -1185,6 +1185,7 @@ export default function ClientDashboard() {
                             <option value="USD">USD</option>
                             <option value="INR">INR</option>
                             <option value="CAD">CAD</option>
+                            <option value="GBP">GBP</option>
                           </select>
                           <input
                             type="number"
@@ -1278,6 +1279,7 @@ export default function ClientDashboard() {
                             <option value="USD">USD</option>
                             <option value="INR">INR</option>
                             <option value="CAD">CAD</option>
+                            <option value="GBP">GBP</option>
                           </select>
                           <input
                             type="number"

--- a/applications-monitor-frontend-main/src/components/ClientDetails.jsx
+++ b/applications-monitor-frontend-main/src/components/ClientDetails.jsx
@@ -495,6 +495,7 @@ const ClientDetails = ({ clientEmail, onClose, userRole = 'admin', onStatusUpdat
                                 <option value="$">$ (USD)</option>
                                 <option value="₹">₹ (INR)</option>
                                 <option value="CAD">CAD</option>
+                                <option value="£">£ (GBP)</option>
                               </select>
                             </div>
                             <div className="col-span-3">

--- a/applications-monitor-frontend-main/src/components/RegisterClient.jsx
+++ b/applications-monitor-frontend-main/src/components/RegisterClient.jsx
@@ -683,6 +683,7 @@ const RegisterClient = () => {
                         <option value="$">$ (Dollar)</option>
                         <option value="₹">₹ (Rupee)</option>
                         <option value="CAD">CAD (Canadian Dollar)</option>
+                        <option value="£">£ (Pound)</option>
                       </select>
                     </div>
                     <div className="col-span-2">

--- a/applications-monitor-frontend-main/src/utils/currencyUtils.js
+++ b/applications-monitor-frontend-main/src/utils/currencyUtils.js
@@ -11,7 +11,7 @@ export const parseAmount = (amountStr) => {
   if (!amountStr) return 0;
   const str = amountStr.toString();
   // Remove currency symbols and whitespace: $, ₹, CAD, commas, spaces
-  const cleaned = str.replace(/[$₹CAD,\s]/gi, '').trim();
+  const cleaned = str.replace(/[$₹£CAD,\s]/gi, '').trim();
   return parseFloat(cleaned) || 0;
 };
 
@@ -25,6 +25,7 @@ export const extractCurrency = (amountStr) => {
   const str = amountStr.toString();
   if (str.startsWith('CAD')) return 'CAD';
   if (str.startsWith('₹')) return '₹';
+  if (str.startsWith('£')) return '£';
   if (str.startsWith('$')) return '$';
   return '';
 };
@@ -46,6 +47,8 @@ export const formatAmount = (amount, currency = '') => {
     return `CAD ${numAmount.toLocaleString()}`;
   } else if (currency === '₹') {
     return `₹${numAmount.toLocaleString()}`;
+  } else if (currency === '£') {
+    return `£${numAmount.toLocaleString()}`;
   } else if (currency === '$') {
     return `$${numAmount.toLocaleString()}`;
   }
@@ -61,6 +64,7 @@ export const formatAmount = (amount, currency = '') => {
 export const getCurrencyPrefix = (currency) => {
   if (currency === 'CAD') return 'CAD';
   if (currency === '₹') return '₹';
+  if (currency === '£') return '£';
   if (currency === '$') return '$';
   return '$';
 };

--- a/applications_monitor_backend/index.js
+++ b/applications_monitor_backend/index.js
@@ -306,7 +306,7 @@ app.post('/api/stripe-webhook', express.raw({ type: 'application/json' }), async
         return res.status(200).json({ received: true, warning: 'unknown plan' });
       }
       const capitalizedPlan = planTypeLower.charAt(0).toUpperCase() + planTypeLower.slice(1);
-      const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹,\s]/g, '') || '0');
+      const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹£,\s]/g, '') || '0');
       const currentPlanPrice = existingClient.planPrice || 0;
       const newAmountPaid = currentAmountPaid + (planPrice - currentPlanPrice);
       const planChanged = String(existingClient.planType || '').toLowerCase() !== planTypeLower;
@@ -335,7 +335,7 @@ app.post('/api/stripe-webhook', express.raw({ type: 'application/json' }), async
     } else if (type === 'addon' && addonApps) {
       const addonType = addonApps; // '250', '500', '1000'
       const addonPrice = parseFloat(amountPaid);
-      const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹,\s]/g, '') || '0');
+      const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹£,\s]/g, '') || '0');
       const newAmountPaid = currentAmountPaid + addonPrice;
       const existingAddons = existingClient.addons || [];
       const newAddon = { type: addonType, price: addonPrice, addedAt: currentDate };
@@ -979,10 +979,11 @@ export const createOrUpdateClient = async (req, res) => {
               : null)
       : null;
 
-    // Detect currency from amountPaid prefix (e.g. "CAD199" → "CAD", "$199" → "USD", "₹199" → "INR")
+    // Detect currency from amountPaid prefix (e.g. "CAD199" → "CAD", "$199" → "USD", "₹199" → "INR", "£199" → "GBP")
     const amountPaidStr = String(amountPaid || "");
     const detectedCurrency = amountPaidStr.toUpperCase().startsWith("CAD") ? "CAD"
       : amountPaidStr.startsWith("₹") ? "INR"
+      : amountPaidStr.startsWith("£") ? "GBP"
       : "USD";
 
     const userData = {
@@ -1366,7 +1367,7 @@ const upgradeClientPlan = async (req, res) => {
       return res.status(404).json({ success: false, error: 'Client not found' });
     }
 
-    const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹,\s]/g, '') || '0');
+    const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹£,\s]/g, '') || '0');
     const currentPlanPrice = existingClient.planPrice || 0;
     const upgradeDifference = planPrice - currentPlanPrice;
     const newAmountPaid = currentAmountPaid + upgradeDifference;
@@ -1456,7 +1457,7 @@ const addClientAddon = async (req, res) => {
       return res.status(404).json({ success: false, error: 'Client not found' });
     }
 
-    const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹,\s]/g, '') || '0');
+    const currentAmountPaid = parseFloat(existingClient.amountPaid?.toString().replace(/[$₹£,\s]/g, '') || '0');
     const newAmountPaid = currentAmountPaid + parseFloat(addonPrice);
 
     const newAddon = {
@@ -4525,8 +4526,8 @@ const getRevenueStats = async (req, res) => {
 
       // If amountPaid is a string, parse it to a number
       if (typeof amountPaid === 'string') {
-        // Remove currency symbols ($, ₹) and any whitespace
-        amountPaid = amountPaid.replace(/[$₹,\s]/g, '').trim();
+        // Remove currency symbols ($, ₹, £) and any whitespace
+        amountPaid = amountPaid.replace(/[$₹£,\s]/g, '').trim();
         // Convert to number, default to 0 if invalid
         amountPaid = parseFloat(amountPaid) || 0;
       }


### PR DESCRIPTION
## Summary
- Adds £ (GBP) as a selectable currency option in Register Client and Edit Client forms
- Adds GBP option to plan-upgrade and addon payment currency dropdowns
- Updates `currencyUtils.js` (parseAmount/extractCurrency/formatAmount/getCurrencyPrefix) to handle £
- Updates backend currency auto-detection and all amount-parsing regexes to recognize £ so GBP amounts save and total correctly in revenue stats

## Test plan
- [ ] Register a new client with currency £ and confirm it saves and displays correctly
- [ ] Edit an existing client's currency to £
- [ ] Add a plan upgrade/addon payment with GBP and confirm amount saves correctly
- [ ] Confirm revenue totals still sum correctly with a mix of $, ₹, CAD, and £ amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)