### PR TITLE
feat: save crmEmail from registration form to client record

### DIFF
--- a/applications_monitor_backend/ClientModel.js
+++ b/applications_monitor_backend/ClientModel.js
@@ -235,6 +235,13 @@ export const ClientSchema = new mongoose.Schema({
     trim: true,
     default: ""
   },
+  crmEmail: {
+    type: String,
+    required: false,
+    lowercase: true,
+    trim: true,
+    default: ""
+  },
   // Dynamic per-plan milestone tracking. Keys come from PLAN_MILESTONES
   // ('started', 'count_250', 'count_350', 'count_700', 'completed').
   // Each value: { sent: Boolean, at: Date, count: Number }.

--- a/applications_monitor_backend/index.js
+++ b/applications_monitor_backend/index.js
@@ -953,6 +953,7 @@ export const createOrUpdateClient = async (req, res) => {
       modeOfPayment,
       status,
       paymentEmail,
+      oldEmail,
     } = req.body;
 
     const emailLower = email.toLowerCase();
@@ -1074,6 +1075,7 @@ export const createOrUpdateClient = async (req, res) => {
         amountPaidDate: amountPaidDate || " ",
         modeOfPayment: modeOfPayment || "paypal",
         paymentEmail: paymentEmailNorm,
+        crmEmail: typeof oldEmail === 'string' ? oldEmail.trim().toLowerCase() : '',
         status: status !== undefined && status !== null && status !== '' ? status : "active",
         isPaused: true,
         onboardingPhase: true,


### PR DESCRIPTION
## Summary
- Add `crmEmail` field to `ClientSchema` in `ClientModel.js` (lowercase, trimmed string, optional)
- Destructure `oldEmail` from `req.body` in `createOrUpdateClient` in `index.js`
- Save `oldEmail` as `crmEmail` in the client document — this field is the email the client uses in the CRM (lead email), which differs from their FlashFire dashboard login email

**Why:** The registration form already has an "email used in crm" field (`oldEmail`) that BDAs fill in, but the backend was silently ignoring it. This field is critical for matching Stripe payments to Meta campaigns in the revenue attribution pipeline (Stripe paymentEmail → Client Tracking crmEmail → CRM clientEmail → metaCampaignName).

## Test plan
- [ ] Register a new client with a CRM email filled in — verify `crmEmail` is saved in `dashboardtrackings` MongoDB collection
- [ ] Run the Stripe revenue attribution script for a date range — verify the new `crmEmail` field improves campaign matching for newly registered clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)