### PR TITLE
feat: derive and backfill client country from amountPaid prefix

### DIFF
--- a/applications-monitor-frontend-main/src/components/ClientJobAnalysis.jsx
+++ b/applications-monitor-frontend-main/src/components/ClientJobAnalysis.jsx
@@ -1359,7 +1359,7 @@ export default function ClientJobAnalysis() {
                       {userRole === 'admin' ? (
                         <select
                           value={
-                            r.clientCountry === 'USA' || r.clientCountry === 'Canada'
+                            ['USA', 'Canada', 'UK'].includes(r.clientCountry)
                               ? r.clientCountry
                               : ''
                           }
@@ -1371,10 +1371,11 @@ export default function ClientJobAnalysis() {
                           <option value="">—</option>
                           <option value="USA">USA</option>
                           <option value="Canada">Canada</option>
+                          <option value="UK">UK</option>
                         </select>
                       ) : (
                         <span className="text-[11px] text-slate-700">
-                          {r.clientCountry === 'USA' || r.clientCountry === 'Canada'
+                          {['USA', 'Canada', 'UK'].includes(r.clientCountry)
                             ? r.clientCountry
                             : '—'}
                         </span>

--- a/applications_monitor_backend/index.js
+++ b/applications_monitor_backend/index.js
@@ -3976,7 +3976,14 @@ app.post('/api/analytics/client-job-analysis', async (req, res) => {
       isPaused: !!c.isPaused,
       onboardingPhase: !!c.onboardingPhase,
       pausedAt: c.pausedAt != null ? new Date(c.pausedAt).toISOString() : null,
-      clientCountry: c.clientCountry === 'USA' || c.clientCountry === 'Canada' ? c.clientCountry : null,
+      clientCountry: (() => {
+        if (c.clientCountry === 'USA' || c.clientCountry === 'Canada' || c.clientCountry === 'UK') return c.clientCountry;
+        const amt = String(c.amountPaid || '');
+        if (amt.startsWith('CAD')) return 'Canada';
+        if (amt.startsWith('£')) return 'UK';
+        if (amt.startsWith('$') || amt.startsWith('₹')) return 'USA';
+        return null;
+      })(),
       addonLimit: (c.addons || []).reduce((sum, a) => {
         const v = parseInt(a.type || a.addonType || 0, 10);
         return sum + (isNaN(v) ? 0 : v);


### PR DESCRIPTION
## Summary
- Backend now derives `clientCountry` from `amountPaid` prefix when not explicitly set (`$`/`₹` → USA, `CAD` → Canada, `£` → UK)
- Added `UK` as a valid country option in backend response (was previously filtered out — only USA & Canada were passed through)
- Frontend dropdown and read-only display updated to include UK alongside USA and Canada
- Backfilled 234 clients in DB with country derived from `amountPaid` (220 USA, 9 Canada, 5 UK); 12 clients skipped due to no currency prefix and need manual update via UI dropdown

## Test plan
- [ ] Open Client Job Analysis tab — Country column should now show values for most clients
- [ ] Verify USA, Canada, and UK all appear in the admin dropdown
- [ ] Verify clients with `£` prefix show UK, `CAD` → Canada, `$`/`₹` → USA
- [ ] Confirm 12 skipped clients (no currency prefix) still show `—` and can be set manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)